### PR TITLE
fix(tls): stop cipher analysis on protocol version alert

### DIFF
--- a/cryptolyzer/tls/ciphers.py
+++ b/cryptolyzer/tls/ciphers.py
@@ -56,6 +56,8 @@ class AnalyzerCipherSuites(AnalyzerTlsBase):
                 return [], []
             if alert.description in (TlsAlertDescription.DECODE_ERROR, TlsAlertDescription.INTERNAL_ERROR):
                 return [], remaining_cipher_suites
+        elif alert.description == TlsAlertDescription.PROTOCOL_VERSION:
+            raise StopIteration
         if alert.description == TlsAlertDescription.INTERNAL_ERROR:  # maybe too many handshake request
             if retried_internal_error:
                 return [], []


### PR DESCRIPTION
## Summary
- Treat a TLS `PROTOCOL_VERSION` alert after cipher discovery has started as the end of cipher enumeration.
- Preserve the existing behavior where an immediate `PROTOCOL_VERSION` alert means no cipher suites are available for that protocol version.

## Test plan
- `.venv/bin/python -m unittest test.tls.test_ciphers`